### PR TITLE
Add new functionality to MonitorTxError

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -56,7 +56,8 @@ orchagent_SOURCES = \
             sfloworch.cpp \
             chassisorch.cpp \
             debugcounterorch.cpp \
-            natorch.cpp
+            natorch.cpp \
+            MonitorTxError.cpp
 
 orchagent_SOURCES += flex_counter/flex_counter_manager.cpp flex_counter/flex_counter_stat_manager.cpp
 orchagent_SOURCES += debug_counter/debug_counter.cpp debug_counter/drop_counter.cpp

--- a/orchagent/MonitorTxError.cpp
+++ b/orchagent/MonitorTxError.cpp
@@ -1,0 +1,230 @@
+//
+// Created by davidza on 1/4/21.
+//
+#include <sstream>
+#include <inttypes.h>
+#include <string>
+
+#include "converter.h"
+#include "MonitorTxError.h"
+#include "timer.h"
+#include "port.h"
+#include "select.h"
+#include "portsorch.h"
+#include "sai_serialize.h"
+#include <array>
+
+using namespace std;
+using namespace swss;
+
+#define TX_POOLING_PERIOD "pooling_period"
+#define TX_THRESHOLD "threshold"
+
+#define POOLING_PERIOD_KEY  "POOLING_PERIOD"
+#define THRESHOLD_KEY "THRESHOLD"
+
+#define STATE_DB_TX_STATE "port_state"
+#define VALUE "value"
+#define STATES_NUMBER 3
+
+static const array<string, STATES_NUMBER> stateNames = { "OK", "NOT_OK", "UNKNOWN" };
+static const string counterName = "SAI_PORT_STAT_IF_OUT_ERRORS";
+static const string portNameMap = "COUNTERS_PORT_NAME_MAP";
+
+MonitorTxError::MonitorTxError(TableConnector configDBTConnector, TableConnector stateDBTConnector) :
+        Orch(configDBTConnector.first, configDBTConnector.second),
+        m_countersDB(new DBConnector(COUNTERS_DB, DBConnector::DEFAULT_UNIXSOCKET, 0)),
+        m_countersTable(new Table(m_countersDB.get(), "COUNTERS")),
+        m_countersPortNameMap(new Table(m_countersDB.get(), COUNTERS_PORT_NAME_MAP)),
+        m_stateTxErrTable(stateDBTConnector.first, stateDBTConnector.second),
+        m_txErrConfigTable(configDBTConnector.first, configDBTConnector.second)
+{
+    SWSS_LOG_ENTER();
+    initTimer(TX_ERROR_CHECK_DEFAULT_TIMER);
+
+    vector <FieldValueTuple> fv;
+    fv.emplace_back(VALUE, to_string(m_poolingPeriod_packets));
+    m_txErrConfigTable.set(POOLING_PERIOD_KEY, fv);
+    fv.clear();
+    fv.emplace_back(VALUE, to_string(m_threshold_sec));
+    m_txErrConfigTable.set(THRESHOLD_KEY, fv);
+
+    SWSS_LOG_DEBUG("MonitorTxError initialized\n");
+}
+
+void MonitorTxError::doTask(Consumer& consumer)
+{
+    SWSS_LOG_ENTER();
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+        string key = kfvKey(t);
+        string op = kfvOp(t);
+        vector <FieldValueTuple> fvs = kfvFieldsValues(t);
+
+        if (op == SET_COMMAND)
+        {
+            if (key == "polling_period")
+            {
+                setThreshold(fvs);
+            }
+            else if (key == "threshold")
+            {
+                setPoolingPeriod(fvs);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unexpected key %s", key.c_str());
+            }
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Unexpected operation %s", op.c_str());
+        }
+        consumer.m_toSync.erase(it++);
+    }
+}
+
+void MonitorTxError::doTask(SelectableTimer& timer)
+{
+    SWSS_LOG_ENTER();
+    if (!gPortsOrch->allPortsReady())
+    {
+        return;
+    }
+    updateAllPortsState();
+}
+
+void MonitorTxError::updateAllPortsState()
+{
+    SWSS_LOG_ENTER();
+    map <string, Port>& portsList = gPortsOrch->getAllPorts();
+    for (auto& entry : portsList)
+    {
+        string name = entry.first;
+        Port p = entry.second;
+
+        if (p.m_type != Port::PHY)
+        {
+            continue;
+        }
+
+        string oidStr;
+        if (!m_countersPortNameMap->hget("", name, oidStr))
+        {
+            SWSS_LOG_ERROR("error getting port name from counters");
+            continue;
+        }
+        updatePortState(oidStr, p);
+    }
+}
+
+void MonitorTxError::updatePortState(string oidStr, Port& port)
+{
+    PortState portState = OK;
+    string txErrStrValue;
+    uint64_t txErrValue;
+    uint64_t txErrDiff;
+
+    if (!m_countersTable->hget(oidStr, counterName, txErrStrValue))
+    {
+        portState = UNKNOWN;
+        SWSS_LOG_ERROR("Cannot take information from table for port %s", oidStr.c_str());
+        return;
+    }
+    try
+    {
+        txErrValue = stoul(txErrStrValue);
+    }
+    catch (...)
+    {
+        SWSS_LOG_ERROR("Cannot change status.");
+        return;
+    }
+
+    txErrDiff = txErrValue - m_lastTxCounters[port.m_alias];
+    if (txErrDiff > m_threshold_sec)
+    {
+        portState = NOT_OK;
+    }
+
+    vector <FieldValueTuple> fieldValuesVector;
+    fieldValuesVector.emplace_back(STATE_DB_TX_STATE, stateNames[portState]);
+    m_stateTxErrTable.set(port.m_alias, fieldValuesVector);
+
+    /* save data for the next update */
+    m_lastTxCounters[port.m_alias] = txErrValue;
+}
+
+MonitorTxError::~MonitorTxError(void)
+{
+    SWSS_LOG_ENTER();
+}
+
+void MonitorTxError::initTimer(int setPoolingPeriod)
+{
+    SWSS_LOG_ENTER();
+    m_poolingPeriod_packets = setPoolingPeriod;
+    auto interv = timespec{ .tv_sec = m_poolingPeriod_packets, .tv_nsec = 0 };
+    timer = new SelectableTimer(interv);
+    auto executor = new ExecutableTimer(timer, this, "TX_ERROR_POOLING_PERIOD");
+    Orch::addExecutor(executor);
+    timer->start();
+}
+
+void MonitorTxError::setThreshold(const vector <FieldValueTuple>& data)
+{
+    SWSS_LOG_ENTER();
+    for (auto element : data)
+    {
+        const auto& field = fvField(element);
+        const auto& value = fvValue(element);
+        if (field == VALUE)
+        {
+            try
+            {
+                m_threshold_sec = stoi(value);
+                SWSS_LOG_NOTICE("Changing threshold value to %s", value.c_str());
+            }
+            catch (...)
+            {
+                SWSS_LOG_WARN("Cannot change threshold to the value entered.");
+            }
+        }
+        else
+        {
+            SWSS_LOG_WARN("Unknown field value");
+        }
+    }
+}
+
+void MonitorTxError::setPoolingPeriod(const vector <FieldValueTuple>& data)
+{
+    SWSS_LOG_ENTER();
+    for (auto element : data)
+    {
+        const auto& field = fvField(element);
+        const auto& value = fvValue(element);
+        if (field == VALUE)
+        {
+            try
+            {
+                // change the interval and reset timer
+                m_poolingPeriod_packets = stoi(value);
+                auto interv = timespec{ .tv_sec = m_poolingPeriod_packets, .tv_nsec = 0 };
+                timer->setInterval(interv);
+                timer->reset();
+                SWSS_LOG_NOTICE("Changing pooling_period value to %s", value.c_str());
+            }
+            catch (...)
+            {
+                SWSS_LOG_WARN("Cannot change pooling_period to the value entered.");
+            }
+        }
+        else
+        {
+            SWSS_LOG_WARN("Unknown field value");
+        }
+    }
+}

--- a/orchagent/MonitorTxError.h
+++ b/orchagent/MonitorTxError.h
@@ -1,0 +1,62 @@
+//
+// Created by davidza on 1/4/21.
+//
+
+#ifndef SONIC_SWSS_MONITORTXERROR_H
+#define SONIC_SWSS_MONITORTXERROR_H
+
+#include <map>
+#include <string>
+
+#include "orch.h"
+#include "portsorch.h"
+#include "table.h"
+#include "selectabletimer.h"
+#include "select.h"
+#include "timer.h"
+
+using namespace std;
+using namespace swss;
+const time_t TX_ERROR_CHECK_DEFAULT_TIMER = 10;
+const uint64_t TX_ERROR_DEFAULT_THRESHOLD = 100;
+extern PortsOrch* gPortsOrch;
+enum PortState
+{
+	OK, NOT_OK, UNKNOWN
+};
+
+class MonitorTxError : public Orch
+{
+public:
+	MonitorTxError(TableConnector configDBTConnector, TableConnector stateDBTConnector);
+	virtual void doTask(swss::SelectableTimer& timer);
+	virtual void doTask(Consumer& consumer);
+	virtual ~MonitorTxError(void);
+
+private:
+	SelectableTimer* timer = nullptr;
+	// counters table - taken from redis
+	shared_ptr <swss::DBConnector> m_countersDB = nullptr;
+	shared_ptr <swss::Table> m_countersTable = nullptr;
+	shared_ptr <Table> m_countersPortNameMap = nullptr;
+
+	// state table
+	Table m_stateTxErrTable;
+	Table m_txErrConfigTable;
+
+	// counetrs of tx errors
+	map <string, uint64_t> m_portsStateTable;
+	map <string, uint64_t> m_lastTxCounters;
+
+	uint64_t m_threshold_sec = TX_ERROR_DEFAULT_THRESHOLD;
+	int m_poolingPeriod_packets = TX_ERROR_CHECK_DEFAULT_TIMER;
+
+	void initTimer(int setPoolingPeriod);
+	void updateAllPortsState();
+    void updatePortState(string portAlias, Port& port);
+	void setThreshold(const vector <FieldValueTuple>& data);
+	void setPoolingPeriod(const vector <FieldValueTuple>& data);
+	void setDefaultConfigParam();
+};
+
+#endif //SONIC_SWSS_MONITORTXERROR_H

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -36,6 +36,7 @@ BufferOrch *gBufferOrch;
 SwitchOrch *gSwitchOrch;
 Directory<Orch*> gDirectory;
 NatOrch *gNatOrch;
+MonitorTxError *gMonitorTxError;
 
 bool gIsNatSupported = false;
 
@@ -219,6 +220,10 @@ bool OrchDaemon::init()
 
     gNatOrch = new NatOrch(m_applDb, m_stateDb, nat_tables, gRouteOrch, gNeighOrch);
 
+    TableConnector configDBConnector(m_configDb, CFG_TX_ERROR_TABLE_NAME);
+    TableConnector stateDBConnector(m_stateDb, STATE_TX_ERROR_TABLE_NAME);
+    gMonitorTxError = new MonitorTxError(configDBConnector, stateDBConnector);
+
     /*
      * The order of the orch list is important for state restore of warm start and
      * the queued processing in m_toSync map after gPortsOrch->allPortsReady() is set.
@@ -227,7 +232,9 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap. This is ensured implicitly by the order of keys in ordered map.
      * For cases when Orch has to process tables in specific order, like PortsOrch during warm start, it has to override Orch::doTask()
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gIntfsOrch, gNeighOrch, gRouteOrch, copp_orch, tunnel_decap_orch, qos_orch, wm_orch, policer_orch, sflow_orch, debug_counter_orch};
+    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gIntfsOrch, gNeighOrch, gRouteOrch, copp_orch,
+                   tunnel_decap_orch, qos_orch, wm_orch, policer_orch, sflow_orch, debug_counter_orch,
+                   gMonitorTxError };
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -31,6 +31,7 @@
 #include "debugcounterorch.h"
 #include "directory.h"
 #include "natorch.h"
+#include "MonitorTxError.h"
 
 using namespace swss;
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
 Added class in orchagent named MonitorTxError - This class will monitor ports TX error counters, and will change the port status if the TX error is above a threshold
 Added it to the orchs list in orchdaemon class
**Why I did it**

**How I verified it**

**Details if related**
